### PR TITLE
Don't rely on body background-color being white

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -14,6 +14,7 @@ body {
   padding:10px;
   font:15pt/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:rgb(20,20,20);
+  background-color:#fff;
   font-weight:300;
   text-align:justify;
 }


### PR DESCRIPTION
This is a browser setting, there is no guarantee for the text and background colors to be black and white, so you should set both if you set one of them.
